### PR TITLE
Change Tracking Coordinate System to Virtual Sensor Frame

### DIFF
--- a/src/model/profiles/profile_Ibeo_LUX_2010.hpp.in
+++ b/src/model/profiles/profile_Ibeo_LUX_2010.hpp.in
@@ -27,9 +27,9 @@ namespace model::profile::Ibeo_LUX_2010 {
         Ibeo_LUX_2010.sensor_view_configuration.set_range(400.0);
         Ibeo_LUX_2010.sensor_view_configuration.set_field_of_view_horizontal(180.0 / 180 * M_PI);
         Ibeo_LUX_2010.sensor_view_configuration.set_field_of_view_vertical(170.0 / 180 * M_PI);
-        Ibeo_LUX_2010.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_x(5.0);
+        Ibeo_LUX_2010.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_x(0.0);
         Ibeo_LUX_2010.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_y(0.0);
-        Ibeo_LUX_2010.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_z(0.489);
+        Ibeo_LUX_2010.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_z(0.0);
         Ibeo_LUX_2010.sensor_view_configuration.mutable_mounting_position()->mutable_orientation()->set_roll(0.0 / 180 * M_PI);
         Ibeo_LUX_2010.sensor_view_configuration.mutable_mounting_position()->mutable_orientation()->set_pitch(-0.5 / 180 * M_PI);
         Ibeo_LUX_2010.sensor_view_configuration.mutable_mounting_position()->mutable_orientation()->set_yaw(0-0.25 / 180 * M_PI);

--- a/src/model/profiles/profile_LongRange_Radar.hpp.in
+++ b/src/model/profiles/profile_LongRange_Radar.hpp.in
@@ -27,9 +27,9 @@ namespace model::profile::LongRange_Radar {
         LongRange_Radar.sensor_view_configuration.set_range(400.0);
         LongRange_Radar.sensor_view_configuration.set_field_of_view_horizontal(180.0 / 180 * M_PI);
         LongRange_Radar.sensor_view_configuration.set_field_of_view_vertical(170.0 / 180 * M_PI);
-        LongRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_x(3.82);
-        LongRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_y(0.35);
-        LongRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_z(0.24);
+        LongRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_x(0.0);
+        LongRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_y(0.0);
+        LongRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_z(0.0);
         LongRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_orientation()->set_roll(0.0 / 180 * M_PI);
         LongRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_orientation()->set_pitch(0.0 / 180 * M_PI);
         LongRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_orientation()->set_yaw(0.0 / 180 * M_PI);

--- a/src/model/profiles/profile_MidRange_Radar.hpp.in
+++ b/src/model/profiles/profile_MidRange_Radar.hpp.in
@@ -27,9 +27,9 @@ namespace model::profile::MidRange_Radar {
         MidRange_Radar.sensor_view_configuration.set_range(200.0);
         MidRange_Radar.sensor_view_configuration.set_field_of_view_horizontal(180.0 / 180 * M_PI);
         MidRange_Radar.sensor_view_configuration.set_field_of_view_vertical(170.0 / 180 * M_PI);
-        MidRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_x(3.82);
-        MidRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_y(0.35);
-        MidRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_z(0.24);
+        MidRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_x(0.0);
+        MidRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_y(0.0);
+        MidRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_z(0.0);
         MidRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_orientation()->set_roll(0.0 / 180 * M_PI);
         MidRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_orientation()->set_pitch(0.0 / 180 * M_PI);
         MidRange_Radar.sensor_view_configuration.mutable_mounting_position()->mutable_orientation()->set_yaw(0.0 / 180 * M_PI);

--- a/src/model/profiles/profile_SCALA_1.hpp.in
+++ b/src/model/profiles/profile_SCALA_1.hpp.in
@@ -27,9 +27,9 @@ namespace model::profile::SCALA_1 {
         SCALA_1.sensor_view_configuration.set_range(400.0);
         SCALA_1.sensor_view_configuration.set_field_of_view_horizontal(180.0 / 180 * M_PI);
         SCALA_1.sensor_view_configuration.set_field_of_view_vertical(170.0 / 180 * M_PI);
-        SCALA_1.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_x(3.82);
-        SCALA_1.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_y(-0.35);
-        SCALA_1.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_z(0.24);
+        SCALA_1.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_x(0.0);
+        SCALA_1.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_y(0.0);
+        SCALA_1.sensor_view_configuration.mutable_mounting_position()->mutable_position()->set_z(0.0);
         SCALA_1.sensor_view_configuration.mutable_mounting_position()->mutable_orientation()->set_roll(0.0 / 180 * M_PI);
         SCALA_1.sensor_view_configuration.mutable_mounting_position()->mutable_orientation()->set_pitch(0.0 / 180 * M_PI);
         SCALA_1.sensor_view_configuration.mutable_mounting_position()->mutable_orientation()->set_yaw(0.0 / 180 * M_PI);

--- a/src/model/strategies/data-extraction-strategy/src/DataExtractionStrategy.cpp
+++ b/src/model/strategies/data-extraction-strategy/src/DataExtractionStrategy.cpp
@@ -254,17 +254,18 @@ double DataExtractionStrategy::calculate_irradiation_gain(double azimuth_angle_r
 
 void DataExtractionStrategy::transform_detections_to_logical_detections(osi3::SensorData& sensor_data, const osi3::LidarDetectionData& detection_data) const
 {
-    osi3::Vector3d mounting_position;
-    osi3::Orientation3d mounting_orientation;
-    if (!profile.sensor_view_configuration.radar_sensor_view_configuration().empty())
+    MountingPosition mounting_pose;
+    if (sensor_data.sensor_view(0).radar_sensor_view_size() > 0)
     {  // radar
-        mounting_position.CopyFrom(profile.sensor_view_configuration.radar_sensor_view_configuration(0).mounting_position().position());
-        mounting_orientation.CopyFrom(profile.sensor_view_configuration.radar_sensor_view_configuration(0).mounting_position().orientation());
+        mounting_pose.CopyFrom(sensor_data.sensor_view(0).radar_sensor_view(0).view_configuration().mounting_position());
+    }
+    else if (sensor_data.sensor_view(0).lidar_sensor_view_size() > 0)
+    {  // lidar
+        mounting_pose.CopyFrom(sensor_data.sensor_view(0).lidar_sensor_view(0).view_configuration().mounting_position());
     }
     else
-    {  // lidar
-        mounting_position.CopyFrom(profile.sensor_view_configuration.lidar_sensor_view_configuration(0).mounting_position().position());
-        mounting_orientation.CopyFrom(profile.sensor_view_configuration.lidar_sensor_view_configuration(0).mounting_position().orientation());
+    {
+        alert("No lidar or radar sensor view found!");
     }
 
     for (const auto& current_detection : detection_data.detection())
@@ -277,7 +278,7 @@ void DataExtractionStrategy::transform_detections_to_logical_detections(osi3::Se
         point_cartesian_sensor.set_x(distance * cos(elevation) * cos(azimuth));
         point_cartesian_sensor.set_y(distance * cos(elevation) * sin(azimuth));
         point_cartesian_sensor.set_z(distance * sin(elevation));
-        osi3::Vector3d point_cartesian_vehicle = TF::transform_from_local_coordinates(point_cartesian_sensor, mounting_orientation, mounting_position);
+        osi3::Vector3d point_cartesian_vehicle = TF::transform_from_local_coordinates(point_cartesian_sensor, mounting_pose.orientation(), mounting_pose.position());
 
         auto* current_logical_detection = sensor_data.mutable_logical_detection_data()->add_logical_detection();
         current_logical_detection->mutable_position()->set_x(point_cartesian_vehicle.x());

--- a/src/model/strategies/data-extraction-strategy/src/DataExtractionStrategy.cpp
+++ b/src/model/strategies/data-extraction-strategy/src/DataExtractionStrategy.cpp
@@ -279,11 +279,14 @@ void DataExtractionStrategy::transform_detections_to_logical_detections(osi3::Se
         point_cartesian_sensor.set_y(distance * cos(elevation) * sin(azimuth));
         point_cartesian_sensor.set_z(distance * sin(elevation));
         osi3::Vector3d point_cartesian_vehicle = TF::transform_from_local_coordinates(point_cartesian_sensor, mounting_pose.orientation(), mounting_pose.position());
+        osi3::Vector3d point_cartesian_virtual_sensor = TF::transform_to_local_coordinates(point_cartesian_vehicle,
+                                                                                           sensor_data.sensor_view(0).mounting_position().orientation(),
+                                                                                           sensor_data.sensor_view(0).mounting_position().position());
 
         auto* current_logical_detection = sensor_data.mutable_logical_detection_data()->add_logical_detection();
-        current_logical_detection->mutable_position()->set_x(point_cartesian_vehicle.x());
-        current_logical_detection->mutable_position()->set_y(point_cartesian_vehicle.y());
-        current_logical_detection->mutable_position()->set_z(point_cartesian_vehicle.z());
+        current_logical_detection->mutable_position()->set_x(point_cartesian_virtual_sensor.x());
+        current_logical_detection->mutable_position()->set_y(point_cartesian_virtual_sensor.y());
+        current_logical_detection->mutable_position()->set_z(point_cartesian_virtual_sensor.z());
         current_logical_detection->set_intensity(current_detection.intensity());
         current_logical_detection->mutable_object_id()->set_value(current_detection.object_id().value());
     }

--- a/src/model/strategies/front-end-strategy/include/frontendstrategy/FrontEndStrategy.hpp
+++ b/src/model/strategies/front-end-strategy/include/frontendstrategy/FrontEndStrategy.hpp
@@ -57,7 +57,7 @@ class FrontEndStrategy : public Strategy
     void apply(osi3::SensorData& sensor_data) override;
 
   private:
-    static void check_sensor_data_input(const osi3::SensorData& sensor_data, const Alert& alert);
+    void check_sensor_data_input(osi3::SensorData& sensor_data, const Alert& alert);
     static void set_sensor_data_timestamp(osi3::SensorData& sensor_data, const osi3::SensorView& input_sensor_view, const Alert& alert);
     static bool simulate_sensor_failure(osi3::SensorData& sensor_data, const Profile& profile, const Log& log);
     static std::vector<GroundTruthObject> bring_ground_truth_objects_to_unified_format(const osi3::SensorView& input_sensor_view,
@@ -70,6 +70,6 @@ class FrontEndStrategy : public Strategy
     static GroundTruthObject get_moving_object_from_ground_truth(const osi3::MovingObject& input_object, const TF::EgoData& ego_data, const osi3::MountingPosition& mounting_pose);
     static void apply_noise_to_visible_vertices(std::vector<GroundTruthObject>& ground_truth_object_list, const Profile& profile);
     static void write_vertices_to_logical_detections(osi3::SensorData& sensor_data, std::vector<GroundTruthObject>& ground_truth_object_list, const TF::EgoData& ego_data);
-    static void write_visible_vertices_to_detections(osi3::SensorData& sensor_data, std::vector<GroundTruthObject>& ground_truth_object_list);
+    void write_visible_vertices_to_detections(osi3::SensorData& sensor_data, std::vector<GroundTruthObject>& ground_truth_object_list);
 };
 #endif  // FRONT_END_STRATEGY_HPP

--- a/src/model/strategies/front-end-strategy/src/FrontEndStrategy.cpp
+++ b/src/model/strategies/front-end-strategy/src/FrontEndStrategy.cpp
@@ -19,6 +19,7 @@ using namespace model;
 void FrontEndStrategy::apply(osi3::SensorData& sensor_data)
 {
     log("Starting Front-End");
+    std::cout << "Starting Front-End" << std::endl;
 
     check_sensor_data_input(sensor_data, alert);
     const osi3::SensorView& input_sensor_view = sensor_data.sensor_view(0);
@@ -58,9 +59,98 @@ void FrontEndStrategy::check_sensor_data_input(osi3::SensorData& sensor_data, co
         sensor_data.mutable_sensor_view(0)->mutable_mounting_position()->mutable_position()->set_y(profile.sensor_view_configuration.mounting_position().position().y());
         sensor_data.mutable_sensor_view(0)->mutable_mounting_position()->mutable_position()->set_z(profile.sensor_view_configuration.mounting_position().position().z());
         sensor_data.mutable_sensor_view(0)->mutable_mounting_position()->mutable_orientation()->set_yaw(profile.sensor_view_configuration.mounting_position().orientation().yaw());
-        sensor_data.mutable_sensor_view(0)->mutable_mounting_position()->mutable_orientation()->set_yaw(profile.sensor_view_configuration.mounting_position().orientation().yaw());
         sensor_data.mutable_sensor_view(0)->mutable_mounting_position()->mutable_orientation()->set_pitch(profile.sensor_view_configuration.mounting_position().orientation().pitch());
         sensor_data.mutable_sensor_view(0)->mutable_mounting_position()->mutable_orientation()->set_roll(profile.sensor_view_configuration.mounting_position().orientation().roll());
+    }
+    if (profile.sensor_view_configuration.lidar_sensor_view_configuration_size() > 0)
+    {
+        bool replace_lidar_mounting = false;
+        if (sensor_data.sensor_view(0).lidar_sensor_view_size() > 0)
+        {
+            auto lidar_sensor_view_config = sensor_data.sensor_view(0).lidar_sensor_view(0).view_configuration();
+            if (lidar_sensor_view_config.has_mounting_position())
+            {
+                const auto& mounting_position_in = lidar_sensor_view_config.mounting_position();
+                const auto& mounting_position_profile = profile.sensor_view_configuration.lidar_sensor_view_configuration(0).mounting_position();
+                if (mounting_position_in.position().x() != mounting_position_profile.position().x() ||
+                    mounting_position_in.position().y() != mounting_position_profile.position().y() ||
+                    mounting_position_in.position().z() != mounting_position_profile.position().z() ||
+                    mounting_position_in.orientation().yaw() != mounting_position_profile.orientation().yaw() ||
+                    mounting_position_in.orientation().pitch() != mounting_position_profile.orientation().pitch() ||
+                    mounting_position_in.orientation().roll() != mounting_position_profile.orientation().roll())
+                {
+                    alert("Input lidar_sensor_view_config mounting position different from profile. Input mounting position will be used.");
+                }
+            }
+            else
+            {
+                alert("Input lidar_sensor_view_config does not contain a mounting position. Mounting position replaced with values from profile");
+                replace_lidar_mounting = true;
+            }
+        }
+        else
+        {
+            alert("Input lidar_sensor_view does not contain a view_configuration. Mounting position replaced with values from profile.");
+
+            replace_lidar_mounting = true;
+            sensor_data.mutable_sensor_view(0)->add_lidar_sensor_view();
+        }
+        if (replace_lidar_mounting)
+        {
+            auto *mounting_position_out = sensor_data.mutable_sensor_view(0)->mutable_lidar_sensor_view(0)->mutable_view_configuration()->mutable_mounting_position();
+            const auto& mounting_position_profile = profile.sensor_view_configuration.lidar_sensor_view_configuration(0).mounting_position();
+            mounting_position_out->mutable_position()->set_x(mounting_position_profile.position().x());
+            mounting_position_out->mutable_position()->set_y(mounting_position_profile.position().y());
+            mounting_position_out->mutable_position()->set_z(mounting_position_profile.position().z());
+            mounting_position_out->mutable_orientation()->set_yaw(mounting_position_profile.orientation().yaw());
+            mounting_position_out->mutable_orientation()->set_pitch(mounting_position_profile.orientation().pitch());
+            mounting_position_out->mutable_orientation()->set_roll(mounting_position_profile.orientation().roll());
+        }
+    }
+    if (profile.sensor_view_configuration.radar_sensor_view_configuration_size() > 0)
+    {
+        bool replace_radar_mounting = false;
+        if (sensor_data.sensor_view(0).radar_sensor_view_size() > 0)
+        {
+            auto radar_sensor_view_config = sensor_data.sensor_view(0).radar_sensor_view(0).view_configuration();
+            if (radar_sensor_view_config.has_mounting_position())
+            {
+                const auto& mounting_position_in = radar_sensor_view_config.mounting_position();
+                const auto& mounting_position_profile = profile.sensor_view_configuration.radar_sensor_view_configuration(0).mounting_position();
+                if (mounting_position_in.position().x() != mounting_position_profile.position().x() ||
+                    mounting_position_in.position().y() != mounting_position_profile.position().y() ||
+                    mounting_position_in.position().z() != mounting_position_profile.position().z() ||
+                    mounting_position_in.orientation().yaw() != mounting_position_profile.orientation().yaw() ||
+                    mounting_position_in.orientation().pitch() != mounting_position_profile.orientation().pitch() ||
+                    mounting_position_in.orientation().roll() != mounting_position_profile.orientation().roll())
+                {
+                    alert("Input radar_sensor_view_config mounting position different from profile. Input mounting position will be used.");
+                }
+            }
+            else
+            {
+                alert("Input radar_sensor_view_config does not contain a mounting position. Mounting position replaced with values from profile");
+                replace_radar_mounting = true;
+            }
+        }
+        else
+        {
+            alert("Input radar_sensor_view does not contain a view_configuration. Mounting position replaced with values from profile.");
+
+            replace_radar_mounting = true;
+            sensor_data.mutable_sensor_view(0)->add_radar_sensor_view();
+        }
+        if (replace_radar_mounting)
+        {
+            auto *mounting_position_out = sensor_data.mutable_sensor_view(0)->mutable_radar_sensor_view(0)->mutable_view_configuration()->mutable_mounting_position();
+            const auto& mounting_position_profile = profile.sensor_view_configuration.radar_sensor_view_configuration(0).mounting_position();
+            mounting_position_out->mutable_position()->set_x(mounting_position_profile.position().x());
+            mounting_position_out->mutable_position()->set_y(mounting_position_profile.position().y());
+            mounting_position_out->mutable_position()->set_z(mounting_position_profile.position().z());
+            mounting_position_out->mutable_orientation()->set_yaw(mounting_position_profile.orientation().yaw());
+            mounting_position_out->mutable_orientation()->set_pitch(mounting_position_profile.orientation().pitch());
+            mounting_position_out->mutable_orientation()->set_roll(mounting_position_profile.orientation().roll());
+        }
     }
 }
 

--- a/src/model/strategies/front-end-strategy/src/FrontEndStrategy.cpp
+++ b/src/model/strategies/front-end-strategy/src/FrontEndStrategy.cpp
@@ -191,17 +191,17 @@ std::vector<GroundTruthObject> FrontEndStrategy::bring_ground_truth_objects_to_u
     std::vector<GroundTruthObject> ground_truth_object_list;
 
     MountingPosition mounting_pose;
-    if (!profile.sensor_view_configuration.radar_sensor_view_configuration().empty())
+    if (input_sensor_view.radar_sensor_view_size() > 0)
     {  // radar
-        mounting_pose.CopyFrom(profile.sensor_view_configuration.radar_sensor_view_configuration(0).mounting_position());
+        mounting_pose.CopyFrom(input_sensor_view.radar_sensor_view(0).view_configuration().mounting_position());
     }
-    else if (!profile.sensor_view_configuration.lidar_sensor_view_configuration().empty())
+    else if (input_sensor_view.lidar_sensor_view_size() > 0)
     {  // lidar
-        mounting_pose.CopyFrom(profile.sensor_view_configuration.lidar_sensor_view_configuration(0).mounting_position());
+        mounting_pose.CopyFrom(input_sensor_view.lidar_sensor_view(0).view_configuration().mounting_position());
     }
     else
     {
-        alert("No lidar or radar sensor view in profile!");
+        alert("No lidar or radar sensor view found!");
     }
 
     for (const auto& current_object : input_sensor_view.global_ground_truth().stationary_object())
@@ -331,13 +331,13 @@ void FrontEndStrategy::write_visible_vertices_to_detections(osi3::SensorData& se
 {
     auto* current_lidar = sensor_data.mutable_feature_data()->add_lidar_sensor();
     MountingPosition mounting_pose;
-    if (!profile.sensor_view_configuration.radar_sensor_view_configuration().empty())
+    if (sensor_data.sensor_view(0).radar_sensor_view_size() > 0)
     {  // radar
-        mounting_pose.CopyFrom(profile.sensor_view_configuration.radar_sensor_view_configuration(0).mounting_position());
+        mounting_pose.CopyFrom(sensor_data.sensor_view(0).radar_sensor_view(0).view_configuration().mounting_position());
     }
-    else if (!profile.sensor_view_configuration.lidar_sensor_view_configuration().empty())
+    else if (sensor_data.sensor_view(0).lidar_sensor_view_size() > 0)
     {  // lidar
-        mounting_pose.CopyFrom(profile.sensor_view_configuration.lidar_sensor_view_configuration(0).mounting_position());
+        mounting_pose.CopyFrom(sensor_data.sensor_view(0).lidar_sensor_view(0).view_configuration().mounting_position());
     }
     current_lidar->mutable_header()->mutable_mounting_position()->mutable_position()->set_x(mounting_pose.position().x());
     current_lidar->mutable_header()->mutable_mounting_position()->mutable_position()->set_y(mounting_pose.position().y());

--- a/src/model/strategies/front-end-strategy/src/FrontEndStrategy.cpp
+++ b/src/model/strategies/front-end-strategy/src/FrontEndStrategy.cpp
@@ -41,7 +41,7 @@ void FrontEndStrategy::apply(osi3::SensorData& sensor_data)
     }
 }
 
-void FrontEndStrategy::check_sensor_data_input(const osi3::SensorData& sensor_data, const Alert& alert)
+void FrontEndStrategy::check_sensor_data_input(osi3::SensorData& sensor_data, const Alert& alert)
 {
     if (sensor_data.sensor_view().empty())
     {
@@ -50,6 +50,17 @@ void FrontEndStrategy::check_sensor_data_input(const osi3::SensorData& sensor_da
     if (sensor_data.sensor_view(0).global_ground_truth().moving_object().empty())
     {
         alert("GT moving objects empty");
+    }
+    if (!sensor_data.sensor_view(0).has_mounting_position())
+    {
+        alert("Input sensor_view does not contain a mounting position. Mounting position replaced with values from profile");
+        sensor_data.mutable_sensor_view(0)->mutable_mounting_position()->mutable_position()->set_x(profile.sensor_view_configuration.mounting_position().position().x());
+        sensor_data.mutable_sensor_view(0)->mutable_mounting_position()->mutable_position()->set_y(profile.sensor_view_configuration.mounting_position().position().y());
+        sensor_data.mutable_sensor_view(0)->mutable_mounting_position()->mutable_position()->set_z(profile.sensor_view_configuration.mounting_position().position().z());
+        sensor_data.mutable_sensor_view(0)->mutable_mounting_position()->mutable_orientation()->set_yaw(profile.sensor_view_configuration.mounting_position().orientation().yaw());
+        sensor_data.mutable_sensor_view(0)->mutable_mounting_position()->mutable_orientation()->set_yaw(profile.sensor_view_configuration.mounting_position().orientation().yaw());
+        sensor_data.mutable_sensor_view(0)->mutable_mounting_position()->mutable_orientation()->set_pitch(profile.sensor_view_configuration.mounting_position().orientation().pitch());
+        sensor_data.mutable_sensor_view(0)->mutable_mounting_position()->mutable_orientation()->set_roll(profile.sensor_view_configuration.mounting_position().orientation().roll());
     }
 }
 
@@ -229,6 +240,21 @@ void FrontEndStrategy::write_vertices_to_logical_detections(osi3::SensorData& se
 void FrontEndStrategy::write_visible_vertices_to_detections(osi3::SensorData& sensor_data, std::vector<GroundTruthObject>& ground_truth_object_list)
 {
     auto* current_lidar = sensor_data.mutable_feature_data()->add_lidar_sensor();
+    MountingPosition mounting_pose;
+    if (!profile.sensor_view_configuration.radar_sensor_view_configuration().empty())
+    {  // radar
+        mounting_pose.CopyFrom(profile.sensor_view_configuration.radar_sensor_view_configuration(0).mounting_position());
+    }
+    else if (!profile.sensor_view_configuration.lidar_sensor_view_configuration().empty())
+    {  // lidar
+        mounting_pose.CopyFrom(profile.sensor_view_configuration.lidar_sensor_view_configuration(0).mounting_position());
+    }
+    current_lidar->mutable_header()->mutable_mounting_position()->mutable_position()->set_x(mounting_pose.position().x());
+    current_lidar->mutable_header()->mutable_mounting_position()->mutable_position()->set_y(mounting_pose.position().y());
+    current_lidar->mutable_header()->mutable_mounting_position()->mutable_position()->set_z(mounting_pose.position().z());
+    current_lidar->mutable_header()->mutable_mounting_position()->mutable_orientation()->set_yaw(mounting_pose.orientation().yaw());
+    current_lidar->mutable_header()->mutable_mounting_position()->mutable_orientation()->set_pitch(mounting_pose.orientation().pitch());
+    current_lidar->mutable_header()->mutable_mounting_position()->mutable_orientation()->set_roll(mounting_pose.orientation().roll());
     for (auto& current_object : ground_truth_object_list)
     {
         for (auto& current_vertex : current_object.visible_bounding_box_vertices_sensor_coord)

--- a/src/model/strategies/tracking-strategy/include/tracking/Tracking.hpp
+++ b/src/model/strategies/tracking-strategy/include/tracking/Tracking.hpp
@@ -51,7 +51,10 @@ class Tracking : public Strategy
 
     void set_object_dimension_with_tracking(const Dimension3d& current_dimension, Dimension3d* new_dimension, bool object_contained_in_history, int historical_object_no) const;
 
-    void transform_gt_object_to_ego_coordinate_system(const MovingObject& current_gt_object, DetectedMovingObject* current_moving_object, const TF::EgoData& ego_data);
+    void transform_gt_object_to_virtual_sensor_mount(const MovingObject& current_gt_object,
+                                                      DetectedMovingObject* current_moving_object,
+                                                      const TF::EgoData& ego_data,
+                                                      const osi3::MountingPosition& virtual_sensor_mount_pos);
 
     static void get_pcl_segment_of_current_object(const LogicalDetectionData& logical_detection_data, Tracking::Data& data_of_current_time_step, uint64_t gt_object_id);
 

--- a/src/model/strategies/tracking-strategy/src/Tracking.cpp
+++ b/src/model/strategies/tracking-strategy/src/Tracking.cpp
@@ -78,7 +78,7 @@ void Tracking::apply(SensorData& sensor_data)
             }
             if (current_gt_object.has_base())
             {
-                transform_gt_object_to_ego_coordinate_system(current_gt_object, current_moving_object, ego_data);
+                transform_gt_object_to_virtual_sensor_mount(current_gt_object, current_moving_object, ego_data, sensor_data.sensor_view(0).mounting_position());
 
                 find_object_in_history(object_contained_in_history, historical_object_no, current_moving_object, object_tracked_in_history);
 
@@ -242,21 +242,28 @@ void Tracking::set_rcs(DetectedMovingObject* current_moving_object)
     current_moving_object->mutable_radar_specifics()->set_rcs(rcs_dbsm);
 }
 
-void Tracking::transform_gt_object_to_ego_coordinate_system(const MovingObject& current_gt_object, DetectedMovingObject* current_moving_object, const TF::EgoData& ego_data)
+void Tracking::transform_gt_object_to_virtual_sensor_mount(const MovingObject& current_gt_object,
+                                                            DetectedMovingObject* current_moving_object,
+                                                            const TF::EgoData& ego_data,
+                                                            const osi3::MountingPosition& virtual_sensor_mount_pos)
 {
 
     /// Relative position of the object in the ego coordinate system (x_rel)
-    current_moving_object->mutable_base()->mutable_position()->CopyFrom(TF::transform_position_from_world_to_ego_coordinates(current_gt_object.base().position(), ego_data));
+    auto object_pos_ego_coord = TF::transform_position_from_world_to_ego_coordinates(current_gt_object.base().position(), ego_data);
+    auto object_pos_virtual_sensor_coord = TF::transform_to_local_coordinates(object_pos_ego_coord, virtual_sensor_mount_pos.orientation(), virtual_sensor_mount_pos.position());
+    current_moving_object->mutable_base()->mutable_position()->CopyFrom(object_pos_virtual_sensor_coord);
 
     /// Relative orientation of object (delta)
-    current_moving_object->mutable_base()->mutable_orientation()->CopyFrom(
-        TF::calc_relative_orientation_to_local(current_gt_object.base().orientation(), ego_data.ego_base.orientation()));
+    auto object_orient_ego_coord = TF::calc_relative_orientation_to_local(current_gt_object.base().orientation(), ego_data.ego_base.orientation());
+    auto object_orient_virtual_sensor_coord = TF::calc_relative_orientation_to_local(object_orient_ego_coord, virtual_sensor_mount_pos.orientation());
+    current_moving_object->mutable_base()->mutable_orientation()->CopyFrom(object_orient_virtual_sensor_coord);
 
     /// Relative velocity of object in ego coordinate system
     if (current_gt_object.base().has_velocity())
     {
-        current_moving_object->mutable_base()->mutable_velocity()->CopyFrom(
-            TF::transform_to_local_coordinates(current_gt_object.base().velocity(), ego_data.ego_base.orientation(), ego_data.ego_base.velocity()));
+        auto object_velocity_ego_coord = TF::transform_to_local_coordinates(current_gt_object.base().velocity(), ego_data.ego_base.orientation(), ego_data.ego_base.velocity());
+        auto object_velocity_virtual_sensor_coord = TF::transform_to_local_coordinates(current_gt_object.base().velocity(), virtual_sensor_mount_pos.orientation(), osi3::Vector3d());
+        current_moving_object->mutable_base()->mutable_velocity()->CopyFrom(object_velocity_virtual_sensor_coord);
     }
     else
     {
@@ -267,7 +274,7 @@ void Tracking::transform_gt_object_to_ego_coordinate_system(const MovingObject& 
     if (current_gt_object.base().has_orientation_rate())
     {
         current_moving_object->mutable_base()->mutable_orientation_rate()->CopyFrom(
-            TF::calc_relative_orientation_to_local(current_gt_object.base().orientation_rate(), ego_data.ego_base.orientation_rate()));
+            TF::calc_relative_orientation_to_local(current_gt_object.base().orientation_rate(), ego_data.ego_base.orientation_rate())); //virtual sensor same as ego, because virtual sensor does not have a separate orientation rate
     }
     else
     {


### PR DESCRIPTION
**Reference to a related issue in the repository**
#7 

**Add a description**
Currently, the Tracking is performed in the vehicle coordinate system (center of rear axle) and also the detected moving objects as output are given with respect to the ego vehicle coordinates. According to the OSI documentation, detected moving object shall be given in virtual sensor coordinates and not in ego vehicle coordinates.

In addition to this change, a proper separation between mounting positions (physical and virtual) between profile and sensor_view input is implemented. If a mounting position (physical and virtual) is not given as input, it is set in the sensor_view with the data from the profile. If a mounting position is given different from the profile, the input is used and the ones set in the profile are disregarded with a warning given in the logging.

**Take this checklist as orientation for yourself, if this PR is ready for Maintainer Review**
- [x] My suggestion follows the [governance rules](https://github.com/openMSL/governance-and-documentation).
- [x] All commits of this PR are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [ ] My changes generate no errors when passing CI tests. 
- [ ] I updated all documentation (readmes incl. figures) according to my changes.
- [ ] I have successfully implemented and tested my fix/feature locally.
- [ ] Appropriate reviewer(s) are assigned.
